### PR TITLE
Change 40sec timeout to 1sec timeout. Zygisk works with 1sec timeout. But doesn't when there is no timeout.

### DIFF
--- a/src/res/bootanim_magisk.rc
+++ b/src/res/bootanim_magisk.rc
@@ -17,7 +17,7 @@ on post-fs-data
 	copy /system/etc/init/magisk/config /debug_ramdisk/.magisk/config
 	rm /dev/.magisk_unblock
 	start magisk_service_x
-	wait /dev/.magisk_unblock 40
+	wait /dev/.magisk_unblock 1
 	rm /dev/.magisk_unblock
 
 service magisk_service_x /debug_ramdisk/magisk --auto-selinux --post-fs-data

--- a/src/res/bootanim_magisk_new.rc
+++ b/src/res/bootanim_magisk_new.rc
@@ -46,7 +46,7 @@ on post-fs-data
     chmod 0755 /debug_ramdisk/loadpolicy.sh
     exec u:r:magisk:s0 0 0 -- /system/bin/sh /debug_ramdisk/loadpolicy.sh
     start magisk_service_x
-    wait /dev/.magisk_unblock 40
+    wait /dev/.magisk_unblock 1
     rm /dev/.magisk_unblock
 
 service magisk_service_x /debug_ramdisk/magisk --post-fs-data


### PR DESCRIPTION
As I tested Zygisk weirdly works with 1sec timeout, but doesn't when there is no timeout. 40sec was so long. I changed it. I suggest this project should do that too. No issues for me with 1sec timeout.

<img width="2560" height="1440" alt="Screenshot_2025-08-04_13 07 24" src="https://github.com/user-attachments/assets/9b765e23-c405-4349-bcd4-1220171d66f1" />
<img width="2560" height="1440" alt="Screenshot_2025-08-04_13 07 39" src="https://github.com/user-attachments/assets/d2ca709f-5612-46bb-a9d6-e1da0a77fd7f" />
<img width="2560" height="1440" alt="Screenshot_2025-08-04_13 07 50" src="https://github.com/user-attachments/assets/3198134e-6bc6-4a29-8c3b-aa2f3b30922a" />
