### PR TITLE
Removed duplicate rm /dev/.magisk_unblock.

### DIFF
--- a/src/res/bootanim_magisk_new.rc
+++ b/src/res/bootanim_magisk_new.rc
@@ -46,7 +46,6 @@ on post-fs-data
     chmod 0755 /debug_ramdisk/loadpolicy.sh
     exec u:r:magisk:s0 0 0 -- /system/bin/sh /debug_ramdisk/loadpolicy.sh
     exec u:r:magisk:s0 0 0 -- /debug_ramdisk/magisk --post-fs-data
-    rm /dev/.magisk_unblock
 
 service magisk_service_y /debug_ramdisk/magisk --service
     class late_start


### PR DESCRIPTION
I've removed in line 49: rm /dev/.magisk_unblock, It exists in line 12. It was a duplicate. And it works fine.
<img width="2560" height="1440" alt="Screenshot_2025-08-05_12 39 47" src="https://github.com/user-attachments/assets/46bb7736-0fc1-4368-a86a-eda8f90f4217" />
<img width="2560" height="1440" alt="Screenshot_2025-08-05_12 39 52" src="https://github.com/user-attachments/assets/fb5bf7cd-63c5-4388-89df-3a52afb6d069" />
